### PR TITLE
Deprecate GUEST_HOSTNAME env var and share hostname with jailer

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -51,9 +51,8 @@ services:
     build:
       context: .
       target: alpine-test
-    environment:
-      - GUEST_HOSTNAME=alpine-test
     command: /usr/local/bin/healthcheck.sh
+    hostname: alpine-test
 
   debian-test:
     extends:
@@ -62,9 +61,8 @@ services:
     build:
       context: .
       target: debian-test
-    environment:
-      - GUEST_HOSTNAME=debian-test
     command: /usr/local/bin/healthcheck.sh
+    hostname: debian-test
 
   ubuntu-test:
     extends:
@@ -73,9 +71,8 @@ services:
     build:
       context: .
       target: ubuntu-test
-    environment:
-      - GUEST_HOSTNAME=ubuntu-test
     command: /usr/local/bin/healthcheck.sh
+    hostname: ubuntu-test
 
   dind-test:
     extends:
@@ -86,5 +83,5 @@ services:
       target: dind-test
     environment:
       - DOCKER_TLS_CERTDIR=
-      - GUEST_HOSTNAME=dind-test
     command: /usr/local/bin/dockerd-entrypoint.sh
+    hostname: dind-test

--- a/overlay/usr/local/bin/healthcheck.sh
+++ b/overlay/usr/local/bin/healthcheck.sh
@@ -11,8 +11,8 @@ lsblk
 
 printenv
 
-if [ -n "${GUEST_HOSTNAME}" ]; then
-    test "${GUEST_HOSTNAME}" = "$(hostname)"
+if [ -n "${HOSTNAME}" ]; then
+    test "${HOSTNAME}" = "$(hostname)"
 fi
 
 ip link list

--- a/start.sh
+++ b/start.sh
@@ -34,7 +34,7 @@ populate_rootfs() {
 
     # Write all environment variable exports to a file in the rootfs
     mkdir -p "${_rootfs_mnt}/etc/profile.d"
-    sh -c 'export -p' | grep -vE "^(export )?(PWD|TERM|USER|SHLVL|PATH|HOME|HOSTNAME|_)=" >"${_rootfs_mnt}/etc/profile.d/fc_exports.sh"
+    sh -c 'export -p' | grep -vE "^(export )?(PWD|TERM|USER|SHLVL|PATH|HOME|_)=" >"${_rootfs_mnt}/etc/profile.d/fc_exports.sh"
 
     # write the guest command to the end of the init script
     echo "exec ${cmd_str}" >>"${_rootfs_mnt}/sbin/init"
@@ -243,10 +243,6 @@ if [ -z "${GUEST_MAC:-}" ]; then
     GUEST_MAC="$(ip_to_mac "${GUEST_IP}")"
 fi
 
-if [ -z "${GUEST_HOSTNAME:-}" ]; then
-    GUEST_HOSTNAME="$(hostname)"
-fi
-
 if [ -z "${KERNEL_BOOT_ARGS:-}" ]; then
     KERNEL_BOOT_ARGS="console=ttyS0 reboot=k panic=1 pci=off random.trust_cpu=on"
 
@@ -255,7 +251,7 @@ if [ -z "${KERNEL_BOOT_ARGS:-}" ]; then
     fi
 fi
 
-KERNEL_BOOT_ARGS="${KERNEL_BOOT_ARGS} $(network_config "${GUEST_IP}" "${TAP_IP}" "${GUEST_HOSTNAME}" eth0)"
+KERNEL_BOOT_ARGS="${KERNEL_BOOT_ARGS} $(network_config "${GUEST_IP}" "${TAP_IP}" "$(hostname)" eth0)"
 
 echo "Virtual CPUs: ${VCPU_COUNT}"
 echo "Memory: ${MEM_SIZE_MIB}M"


### PR DESCRIPTION
Ideally customizing the hostname of the VM should be as simple
as setting the hostname: instruction in the compose file.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>